### PR TITLE
chore(ci): Add pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,65 @@
+name: 'Pre-Commit'
+
+on:
+  # Caches have a certain level of isolation, see https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+  # We run on push to main to have all caches in the main branch so that they can be reused for PRs.
+  push:
+    branches:
+      - main
+  merge_group:
+  pull_request:
+
+# Cancel a previous job if the same workflow is triggers on the same PR or commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    runs-on:
+      labels:
+        - ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          token: ${{ secrets.GH_ACTIONS_TOKEN }}
+      - uses: actions/setup-python
+      - name: Install pre-commit
+        run: |
+          python -m pip install pre-commit
+      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/.cache/pre-commit
+          key: pre-commit|${{ runner.arch }}-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Install pre-commit hooks
+        # Ensure all hooks are installed so that the following pre-commit run step only measures
+        # the time for the actual pre-commit run.
+        run: pre-commit install-hooks
+      # Adapted from https://github.com/pre-commit/action/blob/efd3bcfec120bd343786e46318186153b7bc8c68/action.yml#L19
+      - name: Run pre-commit
+        run: |
+          pre-commit run --verbose --show-diff-on-failure --color=always --all-files
+
+      ############################
+      # Checkout + commit + push when the previous pre-commit run step failed, as that indicates
+      # auto-fixes / formatting updates, but not outside pull-requests to avoid pushing commits without
+      # review to the main branch and also not for draft PRs to avoid pushing commits while the PR is
+      # still being worked on.
+      # Don't run pre-commit a second time after the commit, as that would mark the commit which triggered
+      # the workflow as green, which technically is not correct. A succeeding workflow run after commit + push
+      # will mark the PR as green, if everything is fine.
+
+      - name: Checkout the branch we're running on to enable a commit to it
+        if: ${{ failure() && github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin refs/heads/${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
+          git checkout ${{ github.head_ref }}
+
+      - name: Commit linted files
+        if: ${{ failure() && github.event_name == 'pull_request' }}
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
+        with:
+          message: 'chore(pre-commit): linting'
+          author_name: KrameBot
+          author_email: krame-bot@matt-kramer.com

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install pre-commit
         run: |
           python -m pip install pre-commit
+      - name: Install conda-project
+        run: |
+          conda install conda-project
       - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         with:
           path: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -35,11 +35,11 @@ jobs:
           path: |
             ~/.cache/pre-commit
           key: pre-commit|${{ runner.arch }}-${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Install pre-commit hooks
-        # Ensure all hooks are installed so that the following pre-commit run step only measures
-        # the time for the actual pre-commit run.
-        run: pre-commit install-hooks
-      # Adapted from https://github.com/pre-commit/action/blob/efd3bcfec120bd343786e46318186153b7bc8c68/action.yml#L19
+      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ./envs
+          key: conda-project|${{ hashFiles('conda-lock.dev.yml', 'conda-lock.prod.yml') }}
       - name: Run pre-commit
         run: |
           pre-commit run --verbose --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           token: ${{ secrets.GH_ACTIONS_TOKEN }}
-      - uses: actions/setup-python
+      - uses: actions/setup-python@v5.1.0
       - name: Install pre-commit
         run: |
           python -m pip install pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,12 @@ repos:
     rev: v24.5.2
     hooks:
       - id: generate-renovate-annotations
-        args: ["--disable-environment-creation", "--environment-selector", "-p ./envs/dev"]
+        args: [
+          "--create-command",
+          "conda project install --environment dev"
+          "--environment-selector",
+          "-p ./envs/dev",
+        ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.5.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,11 @@ repos:
     rev: v24.5.2
     hooks:
       - id: generate-renovate-annotations
-        args: [
-          "--create-command",
-          "conda project install --environment dev"
-          "--environment-selector",
-          "-p ./envs/dev",
-        ]
+        args:
+          - "--create-command"
+          - "conda project install --environment dev"
+          - "--environment-selector"
+          - "-p ./envs/dev"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.5.0
     hooks:

--- a/conda-lock.dev.yml
+++ b/conda-lock.dev.yml
@@ -13,8 +13,8 @@
 version: 1
 metadata:
   content_hash:
-    osx-arm64: c1bb815112020ab4e44e0a6476be302d7e319a792d7894563ea07a2ccac28080
-    linux-64: 35e4571459ccbc020d7ad846ef36d13393620466c69e0a6524e147bacacd4b83
+    osx-arm64: 0c34b95c161bc84d5b710ff06e3d46a17f1f03886ce70a467821db9010e6ff2e
+    linux-64: a3e16580b9e9b22a92261e3eb18a6ae29c3d3199065515094f3af410bc0343b1
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -25,7 +25,7 @@ metadata:
   - environment-dev.yml
   - environment-prod.yml
   time_metadata:
-    created_at: '2024-07-04T05:14:26Z'
+    created_at: '2024-07-04T19:17:45Z'
 package:
 - name: _libgcc_mutex
   version: '0.1'
@@ -133,25 +133,25 @@ package:
   category: main
   optional: false
 - name: ca-certificates
-  version: 2024.6.2
+  version: 2024.7.4
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.6.2-hbcca054_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.7.4-hbcca054_0.conda
   hash:
-    md5: 847c3c2905cc467cea52c24f9cfa8080
-    sha256: 979af0932b2a5a26112044891a2d79e402e5ae8166f50fa48b8ebae47c0a2d65
+    md5: 23ab7665c5f63cfb9f1f6195256daac6
+    sha256: c1548a3235376f464f9931850b64b02492f379b2f2bb98bc786055329b080446
   category: main
   optional: false
 - name: ca-certificates
-  version: 2024.6.2
+  version: 2024.7.4
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.6.2-hf0a4a13_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.7.4-hf0a4a13_0.conda
   hash:
-    md5: b534f104f102479402f88f73adf750f5
-    sha256: f5fd189d48965df396d060eb48628cbd9f083f1a1ea79c5236f60d655c7b9633
+    md5: 21f9a33e5fe996189e470c19c5354dbe
+    sha256: 33a61116dae7f369b6ce92a7f2a1ff361ae737c675a493b11feb5570b89e0e3b
   category: main
   optional: false
 - name: certifi
@@ -1457,7 +1457,7 @@ package:
   category: main
   optional: false
 - name: python
-  version: 3.12.3
+  version: 3.12.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -1467,24 +1467,24 @@ package:
     libffi: '>=3.4,<4.0a0'
     libgcc-ng: '>=12'
     libnsl: '>=2.0.1,<2.1.0a0'
-    libsqlite: '>=3.45.2,<4.0a0'
+    libsqlite: '>=3.46.0,<4.0a0'
     libuuid: '>=2.38.1,<3.0a0'
     libxcrypt: '>=4.4.36'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    ncurses: '>=6.4.20240210,<7.0a0'
-    openssl: '>=3.2.1,<4.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    ncurses: '>=6.5,<7.0a0'
+    openssl: '>=3.3.1,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.3-hab00c5b_0_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.4-h194c7f8_0_cpython.conda
   hash:
-    md5: 2540b74d304f71d3e89c81209db4db84
-    sha256: f9865bcbff69f15fd89a33a2da12ad616e98d65ce7c83c644b92e66e5016b227
+    md5: d73490214f536cccb5819e9873048c92
+    sha256: 97a78631e6c928bf7ad78d52f7f070fcf3bd37619fa48dc4394c21cf3058cdee
   category: main
   optional: false
 - name: python
-  version: 3.12.3
+  version: 3.12.4
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1492,18 +1492,18 @@ package:
     bzip2: '>=1.0.8,<2.0a0'
     libexpat: '>=2.6.2,<3.0a0'
     libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.45.2,<4.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    ncurses: '>=6.4.20240210,<7.0a0'
-    openssl: '>=3.2.1,<4.0a0'
+    libsqlite: '>=3.46.0,<4.0a0'
+    libzlib: '>=1.3.1,<2.0a0'
+    ncurses: '>=6.5,<7.0a0'
+    openssl: '>=3.3.1,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.3-h4a7b5fc_0_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.4-h30c5eda_0_cpython.conda
   hash:
-    md5: 8643ab37bece6ae8f112464068d9df9c
-    sha256: c761fb3713ea66bce3889b33b6f400afb2dd192d1fc2686446e9d8166cfcec6b
+    md5: e3e44e0e72aed46dcb810fa3e96784be
+    sha256: 107824b584eb5e43f71df8cb2741019f5c377c734f8309899aa2a6ed53b79a47
   category: main
   optional: false
 - name: python-multipart


### PR DESCRIPTION
Adds a new `pre-commit.yml` workflow. This workflow will commit modified files back to the PR branch, or fail if it can't fix files.

Using this instead of pre-commit.ci since we need to have `conda-project` available for the renovate-gen hook to work.